### PR TITLE
Fix active_support loading issue

### DIFF
--- a/lib/promiscuous.rb
+++ b/lib/promiscuous.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/dependencies/autoload'
 require 'active_support/core_ext'
 require 'active_model/callbacks'


### PR DESCRIPTION
There is an issue with promiscuous when starting subscribers that results in the error:
NameError: uninitialized constant ActiveSupport::Deprecation

The issue is related to this:
https://github.com/rails/rails/issues/19855

This PR will add requiring to active_support prior to the rest of the modules listed below it.  Reading the rails issue above this is actually the accepted practice:
https://github.com/rails/rails/issues/19855#issuecomment-95255718
